### PR TITLE
Unused variable warning fix

### DIFF
--- a/include/boost/multi_array/base.hpp
+++ b/include/boost/multi_array/base.hpp
@@ -463,6 +463,7 @@ protected:
       index bound_adjustment = stride < 0 ? 1 : 0;
       BOOST_ASSERT(((index_bases[n] - bound_adjustment) <= finish) &&
         (finish <= (index_bases[n] + index(extents[n]) - bound_adjustment)));
+      (void)bound_adjustment;
 #endif // BOOST_DISABLE_ASSERTS
 
 


### PR DESCRIPTION
This change enables clean compilation against the library using MSVC 12.0 at level 4 warnings. The warning is issued in release mode only.
