### PR TITLE
Fix clang warning

### DIFF
--- a/include/boost/multi_array/iterator.hpp
+++ b/include/boost/multi_array/iterator.hpp
@@ -60,7 +60,7 @@ class array_iterator
     , private
           value_accessor_generator<T,NumDims>::type
 {
-  friend class iterator_core_access;
+  friend class ::boost::iterator_core_access;
   typedef detail::multi_array::associated_types<T,NumDims> access_t;
 
   typedef iterator_facade<


### PR DESCRIPTION
clang complains about the friend declaration with a warning:

warning : unqualified friend declaration referring to type outside of the nearest enclosing namespace is a Microsoft extension; add a nested name specifier [-Wmicrosoft]
    friend class iterator_core_access;
                       ^
                       ::boost::

Explicitly qualifying the class name with its namespace fixes the warning.
