### PR TITLE
Get rid of iterator.hpp

### DIFF
--- a/include/boost/multi_array/algorithm.hpp
+++ b/include/boost/multi_array/algorithm.hpp
@@ -40,7 +40,7 @@
 //  See http://www.boost.org/libs/multi_array for documentation.
 
 
-#include "boost/iterator.hpp"
+#include <iterator>
 
 namespace boost {
 namespace detail {


### PR DESCRIPTION
It does nothing more than pulling std::iterator into namespace boost and including headers. This library only takes advantage of the included headers. OTOH, pulling std::iterator into boost generates deprecation warnings in MSVC 14.1 when compiling in C++17 mode. Even more, Boost's iterator.hpp is deprecated, too.

Signed-off-by: Daniela Engert <dani@ngrt.de>