### PR TITLE
Documentation Cleanup

### DIFF
--- a/doc/iterator_categories.html
+++ b/doc/iterator_categories.html
@@ -652,7 +652,7 @@ Iterator</a>.
 permissible to make multiple passes through the iterator's range. 
 <h3>Refinement of</h3><a href="http://www.boost.org/libs/utility/CopyConstructible.html">Copy 
 Constructible</a>, <a href="http://www.boost.org/libs/utility/Assignable.html">Assignable</a>, <a href="http://www.sgi.com/tech/stl/DefaultConstructible.html">Default 
-Constructible</a>, and <a href="http://www.sgi.com/tech/stl/EqualityComparable.html">Equality 
+Constructible</a>, and <a href="http://www.rrsd.com/software_development/stl/stl/EqualityComparable.html">Equality 
 Comparable</a> 
 <h3>Associated types</h3>
 <table border="1">
@@ -725,7 +725,7 @@ Traversal Iterator</a>
 Iterator </h3>An iterator that provides constant-time methods for moving forward 
 and backward in arbitrary-sized steps. 
 <h3>Refinement of</h3><a href="#concept_BidirectionalTraversalIterator">Bidirectional 
-Traversal Iterator</a> and <a href="http://www.sgi.com/tech/stl/LessThanComparable.html">Less Than 
+Traversal Iterator</a> and <a href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html">Less Than 
 Comparable</a> where <tt>&lt;</tt> is a total ordering 
 <h3>Associated types</h3>
 <table border="1">

--- a/doc/iterator_categories.html
+++ b/doc/iterator_categories.html
@@ -652,7 +652,7 @@ Iterator</a>.
 permissible to make multiple passes through the iterator's range. 
 <h3>Refinement of</h3><a href="http://www.boost.org/libs/utility/CopyConstructible.html">Copy 
 Constructible</a>, <a href="http://www.boost.org/libs/utility/Assignable.html">Assignable</a>, <a href="http://www.sgi.com/tech/stl/DefaultConstructible.html">Default 
-Constructible</a>, and <a href="http://www.rrsd.com/software_development/stl/stl/EqualityComparable.html">Equality 
+Constructible</a>, and <a href="https://www.boost.org/sgi/stl/EqualityComparable.html">Equality 
 Comparable</a> 
 <h3>Associated types</h3>
 <table border="1">
@@ -725,7 +725,7 @@ Traversal Iterator</a>
 Iterator </h3>An iterator that provides constant-time methods for moving forward 
 and backward in arbitrary-sized steps. 
 <h3>Refinement of</h3><a href="#concept_BidirectionalTraversalIterator">Bidirectional 
-Traversal Iterator</a> and <a href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html">Less Than 
+Traversal Iterator</a> and <a href="https://www.boost.org/sgi/stl/LessThanComparable.html">Less Than 
 Comparable</a> where <tt>&lt;</tt> is a total ordering 
 <h3>Associated types</h3>
 <table border="1">

--- a/doc/reference.html
+++ b/doc/reference.html
@@ -353,21 +353,21 @@ This expression generates a view of the array determined by the
  used to construct <code class="literal">indices</code>.
 </td></tr><tr><td><code class="literal">a == b</code></td><td>bool</td><td>This performs a lexicographical comparison of the
 values of <code class="literal">a</code> and <code class="literal">b</code>.  The element
-type must model <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/EqualityComparable.html" target="_top">EqualityComparable</a> for this
+type must model <a class="ulink" href="https://www.boost.org/sgi/stl/EqualityComparable.html" target="_top">EqualityComparable</a> for this
 expression to be valid.</td></tr><tr><td><code class="literal">a &lt; b</code></td><td>bool</td><td>This performs a lexicographical comparison of the
 values of <code class="literal">a</code> and <code class="literal">b</code>.  The element
-type must model <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
+type must model <a class="ulink" href="https://www.boost.org/sgi/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
 expression to be valid.</td></tr><tr><td><code class="literal">a &lt;= b</code></td><td>bool</td><td>This performs a lexicographical comparison of the
 values of <code class="literal">a</code> and <code class="literal">b</code>.  The element
-type must model <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and
-<a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
+type must model <a class="ulink" href="https://www.boost.org/sgi/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and
+<a class="ulink" href="https://www.boost.org/sgi/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
 expression to be valid.</td></tr><tr><td><code class="literal">a &gt; b</code></td><td>bool</td><td>This performs a lexicographical comparison of the
 values of <code class="literal">a</code> and <code class="literal">b</code>.  The element
-type must model <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and 
-<a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
+type must model <a class="ulink" href="https://www.boost.org/sgi/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and 
+<a class="ulink" href="https://www.boost.org/sgi/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
 expression to be valid.</td></tr><tr><td><code class="literal">a &gt;= b</code></td><td>bool</td><td>This performs a lexicographical comparison of the
 values of <code class="literal">a</code> and <code class="literal">b</code>.  The element
-type must model <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
+type must model <a class="ulink" href="https://www.boost.org/sgi/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
 expression to be valid.</td></tr></tbody></table></div></div><br class="table-break"></div><div class="sect2" title="Complexity guarantees"><div class="titlepage"><div><div><h3 class="title"><a name="idp18588736"></a>Complexity guarantees</h3></div></div></div><code class="literal">begin()</code> and <code class="literal">end()</code> execute in amortized
 constant time.
 <code class="literal">size()</code> executes in at most linear time in the 
@@ -589,7 +589,7 @@ using a replaceable allocator.
 </p><p title="Model Of."><b>Model Of. </b>
 <a class="link" href="#MultiArray" title="MultiArray Concept">MultiArray</a>,
 <a class="ulink" href="../../../libs/utility/CopyConstructible.html" target="_top">CopyConstructible</a>. Depending on the element type, 
-it may also model <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html" target="_top">LessThanComparable</a>. 
+it may also model <a class="ulink" href="https://www.boost.org/sgi/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and <a class="ulink" href="https://www.boost.org/sgi/stl/LessThanComparable.html" target="_top">LessThanComparable</a>. 
 </p><p title="Synopsis"><b>Synopsis. </b></p><pre class="programlisting">
 
 namespace boost {
@@ -818,7 +818,7 @@ of the constructors.
 <a class="link" href="#MultiArray" title="MultiArray Concept">MultiArray</a>,
 <a class="ulink" href="../../../libs/utility/CopyConstructible.html" target="_top">CopyConstructible</a>.
 and depending on the element type, it may also model
-<a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html" target="_top">LessThanComparable</a>. 
+<a class="ulink" href="https://www.boost.org/sgi/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and <a class="ulink" href="https://www.boost.org/sgi/stl/LessThanComparable.html" target="_top">LessThanComparable</a>. 
 Detailed descriptions are provided here only for operations that are
 not described in the <code class="literal">multi_array</code> reference.
 </p><p title="Synopsis"><b>Synopsis. </b></p><pre class="programlisting">
@@ -978,7 +978,7 @@ of the constructors.
 <a class="link" href="#MultiArray" title="MultiArray Concept">MultiArray</a>,
 <a class="ulink" href="../../../libs/utility/CopyConstructible.html" target="_top">CopyConstructible</a>.
 and depending on the element type, it may also model
-<a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html" target="_top">LessThanComparable</a>. 
+<a class="ulink" href="https://www.boost.org/sgi/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and <a class="ulink" href="https://www.boost.org/sgi/stl/LessThanComparable.html" target="_top">LessThanComparable</a>. 
 
 Detailed descriptions are provided here only for operations that are
 not described in the <code class="literal">multi_array</code> reference.
@@ -1143,7 +1143,7 @@ public:
 <p title="Model Of"><strong>Model Of.</strong></p>
 <ul>
 <li><a class="ulink" href=
-"http://www.rrsd.com/software_development/stl/stl/DefaultConstructible.html"
+"https://www.boost.org/sgi/stl/DefaultConstructible.html"
 target="_top"><strong>DefaultConstructible</strong></a></li>
 <li><a class="ulink" href="../../../libs/utility/CopyConstructible.html"
 target="_top"><strong>CopyConstructible</strong></a></li>

--- a/doc/reference.html
+++ b/doc/reference.html
@@ -353,21 +353,21 @@ This expression generates a view of the array determined by the
  used to construct <code class="literal">indices</code>.
 </td></tr><tr><td><code class="literal">a == b</code></td><td>bool</td><td>This performs a lexicographical comparison of the
 values of <code class="literal">a</code> and <code class="literal">b</code>.  The element
-type must model <a class="ulink" href="http://www.sgi.com/tech/stl/EqualityComparable.html" target="_top">EqualityComparable</a> for this
+type must model <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/EqualityComparable.html" target="_top">EqualityComparable</a> for this
 expression to be valid.</td></tr><tr><td><code class="literal">a &lt; b</code></td><td>bool</td><td>This performs a lexicographical comparison of the
 values of <code class="literal">a</code> and <code class="literal">b</code>.  The element
-type must model <a class="ulink" href="http://www.sgi.com/tech/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
+type must model <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
 expression to be valid.</td></tr><tr><td><code class="literal">a &lt;= b</code></td><td>bool</td><td>This performs a lexicographical comparison of the
 values of <code class="literal">a</code> and <code class="literal">b</code>.  The element
-type must model <a class="ulink" href="http://www.sgi.com/tech/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and
-<a class="ulink" href="http://www.sgi.com/tech/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
+type must model <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and
+<a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
 expression to be valid.</td></tr><tr><td><code class="literal">a &gt; b</code></td><td>bool</td><td>This performs a lexicographical comparison of the
 values of <code class="literal">a</code> and <code class="literal">b</code>.  The element
-type must model <a class="ulink" href="http://www.sgi.com/tech/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and 
-<a class="ulink" href="http://www.sgi.com/tech/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
+type must model <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and 
+<a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
 expression to be valid.</td></tr><tr><td><code class="literal">a &gt;= b</code></td><td>bool</td><td>This performs a lexicographical comparison of the
 values of <code class="literal">a</code> and <code class="literal">b</code>.  The element
-type must model <a class="ulink" href="http://www.sgi.com/tech/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
+type must model <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html" target="_top">LessThanComparable</a> for this
 expression to be valid.</td></tr></tbody></table></div></div><br class="table-break"></div><div class="sect2" title="Complexity guarantees"><div class="titlepage"><div><div><h3 class="title"><a name="idp18588736"></a>Complexity guarantees</h3></div></div></div><code class="literal">begin()</code> and <code class="literal">end()</code> execute in amortized
 constant time.
 <code class="literal">size()</code> executes in at most linear time in the 
@@ -589,7 +589,7 @@ using a replaceable allocator.
 </p><p title="Model Of."><b>Model Of. </b>
 <a class="link" href="#MultiArray" title="MultiArray Concept">MultiArray</a>,
 <a class="ulink" href="../../../libs/utility/CopyConstructible.html" target="_top">CopyConstructible</a>. Depending on the element type, 
-it may also model <a class="ulink" href="http://www.sgi.com/tech/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and <a class="ulink" href="http://www.sgi.com/tech/stl/LessThanComparable.html" target="_top">LessThanComparable</a>. 
+it may also model <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html" target="_top">LessThanComparable</a>. 
 </p><p title="Synopsis"><b>Synopsis. </b></p><pre class="programlisting">
 
 namespace boost {
@@ -818,7 +818,7 @@ of the constructors.
 <a class="link" href="#MultiArray" title="MultiArray Concept">MultiArray</a>,
 <a class="ulink" href="../../../libs/utility/CopyConstructible.html" target="_top">CopyConstructible</a>.
 and depending on the element type, it may also model
-<a class="ulink" href="http://www.sgi.com/tech/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and <a class="ulink" href="http://www.sgi.com/tech/stl/LessThanComparable.html" target="_top">LessThanComparable</a>. 
+<a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html" target="_top">LessThanComparable</a>. 
 Detailed descriptions are provided here only for operations that are
 not described in the <code class="literal">multi_array</code> reference.
 </p><p title="Synopsis"><b>Synopsis. </b></p><pre class="programlisting">
@@ -978,7 +978,7 @@ of the constructors.
 <a class="link" href="#MultiArray" title="MultiArray Concept">MultiArray</a>,
 <a class="ulink" href="../../../libs/utility/CopyConstructible.html" target="_top">CopyConstructible</a>.
 and depending on the element type, it may also model
-<a class="ulink" href="http://www.sgi.com/tech/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and <a class="ulink" href="http://www.sgi.com/tech/stl/LessThanComparable.html" target="_top">LessThanComparable</a>. 
+<a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/EqualityComparable.html" target="_top">EqualityComparable</a> and <a class="ulink" href="http://www.rrsd.com/software_development/stl/stl/LessThanComparable.html" target="_top">LessThanComparable</a>. 
 
 Detailed descriptions are provided here only for operations that are
 not described in the <code class="literal">multi_array</code> reference.
@@ -1139,7 +1139,16 @@ public:
   index start();
   index finish();
   size_type size();
-};</pre><p title="Model Of"><b>Model Of. </b>DefaultConstructible,CopyConstructible</p><p title="Methods and Types"><b>Methods and Types. </b></p><div class="variablelist"><dl><dt><span class="term"><code class="function">extent_range(index start, index finish)</code></span></dt><dd><p>  This constructor defines the half open interval
+};</pre>
+<p title="Model Of"><strong>Model Of.</strong></p>
+<ul>
+<li><a class="ulink" href=
+"http://www.rrsd.com/software_development/stl/stl/DefaultConstructible.html"
+target="_top"><strong>DefaultConstructible</strong></a></li>
+<li><a class="ulink" href="../../../libs/utility/CopyConstructible.html"
+target="_top"><strong>CopyConstructible</strong></a></li>
+</ul>
+<p title="Methods and Types"><b>Methods and Types. </b></p><div class="variablelist"><dl><dt><span class="term"><code class="function">extent_range(index start, index finish)</code></span></dt><dd><p>  This constructor defines the half open interval
 <code class="literal">[start,finish)</code>. The expression
 <code class="literal">finish</code> must be greater than <code class="literal">start</code>.
 </p></dd><dt><span class="term"><code class="function">extent_range(index finish)</code></span></dt><dd><p>This constructor defines the half open interval

--- a/doc/user.html
+++ b/doc/user.html
@@ -612,7 +612,7 @@ cases can be found <a href="./test_cases.html">here</a>.
 <h2>Related Work</h2>
 
 <a href="../../array/index.html">boost::array</a>
- and <a href="http://www.sgi.com/tech/stl/Vector.html">std::vector</a> are
+ and <a href="http://en.cppreference.com/w/cpp/container/vector">std::vector</a> are
     one-dimensional containers of user data.  Both manage their own
     memory. <tt>std::valarray</tt> is a low-level 
     C++ Standard Library component


### PR DESCRIPTION
A few documentation links currently point to pages that HP retired along with the rest of the SGI STL website. These links now point either to the Boost mirror site or to cppreference.com.