### PR TITLE
Fix #39 Replace deprecated boost::array::assign with boost::array::fill

### DIFF
--- a/include/boost/multi_array/multi_array_ref.hpp
+++ b/include/boost/multi_array/multi_array_ref.hpp
@@ -103,7 +103,7 @@ public:
     boost::function_requires<
       CollectionConcept<ExtentList> >();
 
-    index_base_list_.assign(0);
+    index_base_list_.fill(0);
     init_multi_array_ref(extents.begin());
   }
   
@@ -340,7 +340,7 @@ public:
      init_multi_array_ref(extents);
    } else {
      boost::array<index,NumDims> extent_list;
-     extent_list.assign(0);
+     extent_list.fill(0);
      init_multi_array_ref(extent_list.begin());
    }
  }

--- a/include/boost/multi_array/storage_order.hpp
+++ b/include/boost/multi_array/storage_order.hpp
@@ -48,14 +48,14 @@ namespace boost {
       for (size_type i=0; i != NumDims; ++i) {
         ordering_[i] = NumDims - 1 - i;
       }
-      ascending_.assign(true);
+      ascending_.fill(true);
     }
 
     general_storage_order(const fortran_storage_order&) {
       for (size_type i=0; i != NumDims; ++i) {
         ordering_[i] = i;
       }
-      ascending_.assign(true);
+      ascending_.fill(true);
     }
 
     size_type ordering(size_type dim) const { return ordering_[dim]; }

--- a/include/boost/multi_array/view.hpp
+++ b/include/boost/multi_array/view.hpp
@@ -90,7 +90,7 @@ public:
   }
 
   void reindex(index value) {
-    index_base_list_.assign(value);
+    index_base_list_.fill(value);
     origin_offset_ =
       this->calculate_indexing_offset(stride_list_,index_base_list_);
   }
@@ -231,7 +231,7 @@ public: // should be protected
                            const boost::array<Index,NumDims>& strides): 
     base_(base), origin_offset_(0) {
 
-    index_base_list_.assign(0);
+    index_base_list_.fill(0);
 
     // Get the extents and strides
     boost::detail::multi_array::


### PR DESCRIPTION
Fix #39 Replace deprecated boost::array::assign with boost::array::fill to avoid warnings in MSVC

I did NOT verify, that this PR covers all occurrences. It is just covering what I am using in my project.