### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(boost_multi_array
     Boost::functional
     Boost::iterator
     Boost::mpl
-    Boost::static_assert
     Boost::type_traits
 )
 

--- a/build.jam
+++ b/build.jam
@@ -14,7 +14,6 @@ constant boost_dependencies :
     /boost/functional//boost_functional
     /boost/iterator//boost_iterator
     /boost/mpl//boost_mpl
-    /boost/static_assert//boost_static_assert
     /boost/type_traits//boost_type_traits ;
 
 project /boost/multi_array


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.